### PR TITLE
Replace Calypso Mocks

### DIFF
--- a/libs/daedalus/src/lib.rs
+++ b/libs/daedalus/src/lib.rs
@@ -135,17 +135,7 @@ pub fn gen_encode_data(_item: TokenStream) -> TokenStream {
         use calypso_cangen::can_types::*;
         use crate::data::{EncodeData, FormatData};
     };
-    let mut __encode_functions = quote! {
-        pub fn encode_mock(data: Vec<f32>) -> EncodeData {
-            let mut writer = BitWriter::endian(Vec::new(), BigEndian);
-            writer.write_from::<u8>(data.len() as u8).unwrap();
-            EncodeData {
-                value: writer.into_writer(),
-                id: 2047,
-                is_ext: false,
-            }
-        }
-    };
+    let mut __encode_functions = quote! {};
     let mut __encode_map_entries = ProcMacro2TokenStream::new();
     let mut __encode_key_list_entries = ProcMacro2TokenStream::new();
     let mut __encode_key_list_size: usize = 0;

--- a/libs/daedalus/src/lib.rs
+++ b/libs/daedalus/src/lib.rs
@@ -27,14 +27,7 @@ pub fn gen_decode_data(_item: TokenStream) -> TokenStream {
         use calypso_cangen::can_types::*;
         use crate::data::{DecodeData, FormatData};
     };
-    let mut __decode_functions = quote! {
-        pub fn decode_mock(_data: &[u8]) -> Vec::<DecodeData> {
-            let result = vec![
-                DecodeData::new(vec![0.0], "Calypso/Unknown", "")
-            ];
-            result
-        }
-    };
+    let mut __decode_functions = quote! {};
     let mut __decode_map_entries = ProcMacro2TokenStream::new();
 
     // Iterate through CAN spec directory and generate decode functions/mappings

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn read_siren(pub_path: &str, send_map: Arc<RwLock<HashMap<u32, EncodeData>>>) -
         let key_owned = key.to_owned();
         let encoder_func = match ENCODE_FUNCTION_MAP.get(&key_owned) {
             Some(func) => *func,
-            None => encode_mock,
+            None => panic!("An unknown message was initialized!"),
         };
         let ret = encoder_func(Vec::new());
         writable_send_map.insert(ret.id, ret);
@@ -196,11 +196,14 @@ fn read_siren(pub_path: &str, send_map: Arc<RwLock<HashMap<u32, EncodeData>>>) -
                     }
                 };
 
-                let encoder_func = match ENCODE_FUNCTION_MAP.get(&key) {
-                    Some(func) => *func,
-                    None => encode_mock,
+                let ret = match ENCODE_FUNCTION_MAP.get(&key) {
+                    Some(func) => func(buf.data),
+                    None => EncodeData {
+                        value: vec![buf.data.len().try_into().unwrap_or_default()],
+                        id: 2047,
+                        is_ext: false,
+                    },
                 };
-                let ret = encoder_func(buf.data);
 
                 send_map
                     .write()

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,11 +76,10 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
                     socketcan::Id::Standard(std) => std.as_raw().into(),
                     socketcan::Id::Extended(ext) => ext.as_raw(),
                 };
-                let decoder_func = match DECODE_FUNCTION_MAP.get(&id) {
-                    Some(func) => *func,
-                    None => decode_mock,
-                };
-                decoder_func(data)
+                match DECODE_FUNCTION_MAP.get(&id) {
+                    Some(func) => func(data),
+                    None => vec![DecodeData::new(vec![id as f32], "Calypso/Unknown", "ID")],
+                }
             }
             // CanRemoteFrame
             Ok(CanFrame::Remote(remote_frame)) => {


### PR DESCRIPTION
## Changes

_Explanation of changes goes here_

Remove encode and decode mock from the daedelus layer.

Replace them with:
- Decode Mock: `Calypso/Unknown`, value= the ID of the message that could not be decoded
- Encode Mock: `Calypso/Bidir/Unknown` value=the number of times that an invalid encode key is recieved.

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## To Do

_Any remaining things that need to get done_

- [ ] item 1
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] No merge conflicts
- [ ] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #79 
