### PR TITLE
MQTT multi-client messages

### DIFF
--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -12,10 +12,6 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
         "decode_{}",
         msg.desc.clone().to_lowercase().replace(' ', "_")
     );
-    // let clients: Option<Vec<String>> = match msg.clients {
-    //     Some(c) => Some(c),
-    //     _ => None,
-    // };
     let min_size: usize = msg.points.iter().map(|point| point.size).sum::<usize>() / 8;
     let result_len: usize = msg
         .fields

--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -62,8 +62,11 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
 /**
  *  Function to generate DecodeData struct for decoding a NetField
  */
-fn gen_decoder_field(field: &mut NetField, points: &mut [CANPoint], clients: &Option<Vec<u16>>)
-    -> ProcMacro2TokenStream {
+fn gen_decoder_field(
+    field: &mut NetField,
+    points: &mut [CANPoint],
+    clients: &Option<Vec<u16>>,
+) -> ProcMacro2TokenStream {
     // First, check that all of the correlated points are to be parsed
     // If not, return a blank TokenStream
     if !field

--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -12,6 +12,10 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
         "decode_{}",
         msg.desc.clone().to_lowercase().replace(' ', "_")
     );
+    // let clients: Option<Vec<String>> = match msg.clients {
+    //     Some(c) => Some(c),
+    //     _ => None,
+    // };
     let min_size: usize = msg.points.iter().map(|point| point.size).sum::<usize>() / 8;
     let result_len: usize = msg
         .fields
@@ -39,7 +43,7 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
     let field_decoders = msg
         .fields
         .iter_mut()
-        .map(|field| gen_decoder_field(field, &mut msg.points, ))
+        .map(|field| gen_decoder_field(field, &mut msg.points, &msg.clients))
         .collect::<Vec<ProcMacro2TokenStream>>()
         .into_iter()
         .fold(ProcMacro2TokenStream::new(), |mut acc, ts| {
@@ -62,7 +66,7 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
 /**
  *  Function to generate DecodeData struct for decoding a NetField
  */
-fn gen_decoder_field(field: &mut NetField, points: &mut [CANPoint], clients: Vec<String>)
+fn gen_decoder_field(field: &mut NetField, points: &mut [CANPoint], clients: &Option<Vec<u16>>)
     -> ProcMacro2TokenStream {
     // First, check that all of the correlated points are to be parsed
     // If not, return a blank TokenStream
@@ -136,11 +140,18 @@ fn gen_decoder_field(field: &mut NetField, points: &mut [CANPoint], clients: Vec
         &format!(#topic_format_string, #topic_format_values)
     };
 
+    // Add any additional clients to DecodeData struct
+    let add_clients = match clients {
+        Some(cl) => quote! { Some(vec![#(#cl),*])},
+        None => quote! { None },
+    };
+
     quote! {
         result.push(
             DecodeData::new(vec![#values],
                 #topic,
-                #unit)
+                #unit,
+                #add_clients)
         );
     }
 }

--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -39,7 +39,7 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
     let field_decoders = msg
         .fields
         .iter_mut()
-        .map(|field| gen_decoder_field(field, &mut msg.points))
+        .map(|field| gen_decoder_field(field, &mut msg.points, ))
         .collect::<Vec<ProcMacro2TokenStream>>()
         .into_iter()
         .fold(ProcMacro2TokenStream::new(), |mut acc, ts| {
@@ -62,7 +62,8 @@ pub fn gen_decoder_fn(msg: &mut CANMsg) -> ProcMacro2TokenStream {
 /**
  *  Function to generate DecodeData struct for decoding a NetField
  */
-fn gen_decoder_field(field: &mut NetField, points: &mut [CANPoint]) -> ProcMacro2TokenStream {
+fn gen_decoder_field(field: &mut NetField, points: &mut [CANPoint], clients: Vec<String>)
+    -> ProcMacro2TokenStream {
     // First, check that all of the correlated points are to be parsed
     // If not, return a blank TokenStream
     if !field

--- a/libs/calypso-cangen/src/can_types.rs
+++ b/libs/calypso-cangen/src/can_types.rs
@@ -19,6 +19,7 @@ pub struct CANMsg {
     pub key: Option<String>,
     pub is_ext: Option<bool>,
     pub sim_freq: Option<f32>,
+    pub clients: Option<Vec<String>>,
 }
 
 /**

--- a/libs/calypso-cangen/src/can_types.rs
+++ b/libs/calypso-cangen/src/can_types.rs
@@ -19,7 +19,7 @@ pub struct CANMsg {
     pub key: Option<String>,
     pub is_ext: Option<bool>,
     pub sim_freq: Option<f32>,
-    pub clients: Option<Vec<String>>,
+    pub clients: Option<Vec<u16>>,
 }
 
 /**

--- a/libs/calypso-cangen/src/lib.rs
+++ b/libs/calypso-cangen/src/lib.rs
@@ -8,5 +8,4 @@ pub mod validate;
  *  Used by all daedalus macros
  *  Filepath is relative to project root (i.e. /Calypso)
  */
-// pub const CANGEN_SPEC_PATH: &str = "./Embedded-Base/cangen/can-messages/";
-pub const CANGEN_SPEC_PATH: &str = "./test/";
+pub const CANGEN_SPEC_PATH: &str = "./Embedded-Base/cangen/can-messages/";

--- a/libs/calypso-cangen/src/lib.rs
+++ b/libs/calypso-cangen/src/lib.rs
@@ -8,4 +8,5 @@ pub mod validate;
  *  Used by all daedalus macros
  *  Filepath is relative to project root (i.e. /Calypso)
  */
-pub const CANGEN_SPEC_PATH: &str = "./Embedded-Base/cangen/can-messages/";
+// pub const CANGEN_SPEC_PATH: &str = "./Embedded-Base/cangen/can-messages/";
+pub const CANGEN_SPEC_PATH: &str = "./test/";

--- a/src/data.rs
+++ b/src/data.rs
@@ -7,7 +7,7 @@ pub struct DecodeData {
     pub value: Vec<f32>,
     pub topic: String,
     pub unit: String,
-    pub clients: Option<Vec<String>>,
+    pub clients: Option<Vec<u16>>,
 }
 
 /**
@@ -19,8 +19,8 @@ impl fmt::Display for DecodeData {
 
         write!(
             f,
-            "topic: {}, value: {:#?}, unit: {}",
-            self.topic, self.value, self.unit
+            "topic: {}, value: {:#?}, unit: {}, clients: {:#?}",
+            self.topic, self.value, self.unit, self.clients
         )
     }
 }
@@ -34,12 +34,14 @@ impl DecodeData {
      * @param id: the id of the data
      * @param value: the value of the data
      * @param topic: the topic of the data
+     * @param clients: additional MQTT clients
      */
-    pub fn new(value: Vec<f32>, topic: &str, unit: &str) -> Self {
+    pub fn new(value: Vec<f32>, topic: &str, unit: &str, clients: Option<Vec<u16>>) -> Self {
         Self {
             value,
             topic: topic.to_string(),
             unit: unit.to_string(),
+            clients,
         }
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -7,6 +7,7 @@ pub struct DecodeData {
     pub value: Vec<f32>,
     pub topic: String,
     pub unit: String,
+    pub clients: Option<Vec<String>>,
 }
 
 /**

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
     // let mut client = MqttClient::new(pub_path, "calypso-decoder");
     let mut clients = HashMap::from([
         (1883, MqttClient::new(pub_path, "calypso-decoder")),
-        (1882, MqttClient::new("localhost:1882", "calypso-2"))
+        (1882, MqttClient::new("localhost:1882", "calypso-priority"))
     ]);
     for (port, client) in &mut clients {
         if client.connect().is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,14 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
     // let mut client = MqttClient::new(pub_path, "calypso-decoder");
     let mut clients = HashMap::from([
         (1883, MqttClient::new(pub_path, "calypso-decoder")),
-        (1882, MqttClient::new("localhost:1882", "calypso-priority"))
+        (1882, MqttClient::new("localhost:1882", "calypso-priority")),
     ]);
     for (port, client) in &mut clients {
         if client.connect().is_err() {
-            println!("Unable to connect to host on port {}, going into reconnection mode.", port);
+            println!(
+                "Unable to connect to host on port {}, going into reconnection mode.",
+                port
+            );
             if client.reconnect().is_ok() {
                 println!("Reconnected to host on port {}!", port);
             }
@@ -67,7 +70,7 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
         .expect("Failed to set error mask on CAN socket!");
 
     thread::spawn(move || loop {
-        for (_, client) in &mut clients {
+        for client in clients.values_mut() {
             if !client.is_connected() {
                 println!("[read_can] Unable to connect to Siren, going into reconnection mode.");
                 if client.reconnect().is_ok() {
@@ -86,7 +89,12 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
                 };
                 match DECODE_FUNCTION_MAP.get(&id) {
                     Some(func) => func(data),
-                    None => vec![DecodeData::new(vec![id as f32], "Calypso/Unknown", "ID", None)],
+                    None => vec![DecodeData::new(
+                        vec![id as f32],
+                        "Calypso/Unknown",
+                        "ID",
+                        None,
+                    )],
                 }
             }
             // CanRemoteFrame

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -78,6 +78,7 @@ impl SimComponent {
             self.points.iter().map(|p| p.get_value()).collect(),
             &topic_name,
             &self.unit,
+            None,
         )
     }
 


### PR DESCRIPTION
## Changes

Adding a `clients` field to a CAN message allows the message to be sent to multiple MQTT brokers apart from the default on `mqtt://localhost:1883`. 

In the JSON, only a new port should be added under the list of clients, e.g.:
```json
"clients": [
  1882
]
```
This will tell Calypso that in addition to sending this message to the broker at `localhost:1883`, it should also send it to the broker at `localhost:1882`. 

The `clients` field is added to the `DecodeData` struct for all fields in a message when relevant CAN messages are decoded.

At the moment, only `localhost:1883` and `localhost:1882` are supported, so the only viable member of `clients` is `1882`. This functionality can be easily expanded in the future by adding another client to the HashMap of clients in `main.rs/read_can()`