### PR TITLE
Added divide39 format for CAN messages

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -147,9 +147,9 @@ impl FormatData {
 
     /* Scales the data by 39. Added for the Segment Total Volts CAN msg */
     pub fn divide39_d(value: f32) -> f32 {
-        value / 39
+        value / 39.0
     }
     pub fn divide39_e(value: f32) -> f32 {
-        value * 39
+        value * 39.0
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -144,4 +144,12 @@ impl FormatData {
     pub fn multiply5_e(value: f32) -> f32 {
         value / 5.0
     }
+
+    /* Scales the data by 39. Added for the Segment Total Volts CAN msg */
+    pub fn divide39_d(value: f32) -> f32 {
+        value / 39
+    }
+    pub fn divide39_e(value: f32) -> f32 {
+        value * 39
+    }
 }


### PR DESCRIPTION
## Changes
Added "divide39" format for CAN msgs. Used for the total voltage CAN message

## Notes
Not tested yetr

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
